### PR TITLE
Swap ORIG/RESP bytes back to what they were previously

### DIFF
--- a/pcap-to-pkt-with-headers/main.go
+++ b/pcap-to-pkt-with-headers/main.go
@@ -12,8 +12,8 @@ import (
 )
 
 var MAGIC = []byte("\x01PKT")
-var FLOW_RESP = []byte("\x01")
-var FLOW_ORIG = []byte("\x02")
+var FLOW_ORIG = []byte("\x01")
+var FLOW_RESP = []byte("\x02")
 
 func simplify(r *pcapgo.Reader, w io.Writer) (int, error) {
 

--- a/pcap-to-pkt/main.go
+++ b/pcap-to-pkt/main.go
@@ -12,8 +12,8 @@ import (
 )
 
 var MAGIC = []byte("\x01PKT")
-var FLOW_RESP = []byte("\x01")
-var FLOW_ORIG = []byte("\x02")
+var FLOW_ORIG = []byte("\x01")
+var FLOW_RESP = []byte("\x02")
 
 func simplify(r *pcapgo.Reader, w io.Writer) (int, error) {
 


### PR DESCRIPTION
This was breaking Zeek's fuzzers from reading packets correctly. It was
changed in c3356b3eb58f300400787bfcc10e27147adb867c.