### PR TITLE
pkt-to...: Align is_orig determination with Zeek's implementation

### DIFF
--- a/pkt-to-pcap-udp/main.go
+++ b/pkt-to-pcap-udp/main.go
@@ -37,7 +37,7 @@ func (b *BufferSplitter) Next() (bool, []byte, error) {
 		return false, []byte{}, io.EOF
 	}
 	b.data = b.data[len(MAGIC):]
-	is_orig := (b.data[0] & FLOW_ORIG) == 0x01
+	is_orig := (b.data[0] & FLOW_ORIG) == FLOW_ORIG
 	//fmt.Printf("Next byte is %d. is_orig=%v\n", b.data[0], is_orig)
 	//skip is_orig
 	b.data = b.data[1:]

--- a/pkt-to-pcap-udp/main.go
+++ b/pkt-to-pcap-udp/main.go
@@ -16,7 +16,6 @@ import (
 
 var MAGIC = []byte("\x01PKT")
 var FLOW_ORIG = byte('\x01')
-var FLOW_RESP = byte('\x02')
 
 type BufferSplitter struct {
 	data []byte // Could this just be a type alias for []byte?
@@ -38,7 +37,7 @@ func (b *BufferSplitter) Next() (bool, []byte, error) {
 		return false, []byte{}, io.EOF
 	}
 	b.data = b.data[len(MAGIC):]
-	is_orig := (b.data[0] == FLOW_ORIG)
+	is_orig := (b.data[0] & FLOW_ORIG) == 0x01
 	//fmt.Printf("Next byte is %d. is_orig=%v\n", b.data[0], is_orig)
 	//skip is_orig
 	b.data = b.data[1:]

--- a/pkt-to-pcap/main.go
+++ b/pkt-to-pcap/main.go
@@ -37,7 +37,7 @@ func (b *BufferSplitter) Next() (bool, []byte, error) {
 		return false, []byte{}, io.EOF
 	}
 	b.data = b.data[len(MAGIC):]
-	is_orig := (b.data[0] & FLOW_ORIG) == 0x01
+	is_orig := (b.data[0] & FLOW_ORIG) == FLOW_ORIG
 	//fmt.Printf("Next byte is %d. is_orig=%v\n", b.data[0], is_orig)
 	//skip is_orig
 	b.data = b.data[1:]

--- a/pkt-to-pcap/main.go
+++ b/pkt-to-pcap/main.go
@@ -16,7 +16,6 @@ import (
 
 var MAGIC = []byte("\x01PKT")
 var FLOW_ORIG = byte('\x01')
-var FLOW_RESP = byte('\x02')
 
 type BufferSplitter struct {
 	data []byte // Could this just be a type alias for []byte?
@@ -38,7 +37,7 @@ func (b *BufferSplitter) Next() (bool, []byte, error) {
 		return false, []byte{}, io.EOF
 	}
 	b.data = b.data[len(MAGIC):]
-	is_orig := (b.data[0] == FLOW_ORIG)
+	is_orig := (b.data[0] & FLOW_ORIG) == 0x01
 	//fmt.Printf("Next byte is %d. is_orig=%v\n", b.data[0], is_orig)
 	//skip is_orig
 	b.data = b.data[1:]
@@ -107,7 +106,7 @@ func main() {
 	if len(flag.Args()) != 3 {
 		fmt.Printf("Usage: %s infile network_interface port\n", os.Args[0])
 		fmt.Printf("\nThis streams the packets to network interface on the port specified, and\n")
-		fmt.Printf("will need to be captured by tcpdump/wireshark/etc.\n");
+		fmt.Printf("will need to be captured by tcpdump/wireshark/etc.\n")
 		os.Exit(1)
 	}
 

--- a/pkt-with-headers-to-pcap/main.go
+++ b/pkt-with-headers-to-pcap/main.go
@@ -39,7 +39,7 @@ func (b *BufferSplitter) Next() (bool, []byte, error) {
 		return false, []byte{}, io.EOF
 	}
 	b.data = b.data[len(MAGIC):]
-	is_orig := (b.data[0] & FLOW_ORIG) == 0x01
+	is_orig := (b.data[0] & FLOW_ORIG) == FLOW_ORIG
 	//fmt.Printf("Next byte is %d. is_orig=%v\n", b.data[0], is_orig)
 	//skip is_orig
 	b.data = b.data[1:]

--- a/pkt-with-headers-to-pcap/main.go
+++ b/pkt-with-headers-to-pcap/main.go
@@ -18,7 +18,6 @@ import (
 
 var MAGIC = []byte("\x01PKT")
 var FLOW_ORIG = byte('\x01')
-var FLOW_RESP = byte('\x02')
 
 type BufferSplitter struct {
 	data []byte // Could this just be a type alias for []byte?
@@ -40,7 +39,7 @@ func (b *BufferSplitter) Next() (bool, []byte, error) {
 		return false, []byte{}, io.EOF
 	}
 	b.data = b.data[len(MAGIC):]
-	is_orig := (b.data[0] == FLOW_ORIG)
+	is_orig := (b.data[0] & FLOW_ORIG) == 0x01
 	//fmt.Printf("Next byte is %d. is_orig=%v\n", b.data[0], is_orig)
 	//skip is_orig
 	b.data = b.data[1:]


### PR DESCRIPTION
Zeek's FuzzBuffer implementation does:

   is_orig = byte & 0x01

which isn't the same as what was done here (byte == 0x01).

Align this implementation to what Zeek is doing.

I hope I caught them all. Only tested pkt-to-pcap though.