### PR TITLE
pkt-to-pcap: Support file://name.pcap in place of interface name

### DIFF
--- a/pkt-to-pcap/tcp.go
+++ b/pkt-to-pcap/tcp.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	"github.com/google/gopacket/pcap"
 )
 
 var (
@@ -22,8 +21,13 @@ type Endpoint struct {
 	tcp layers.TCP
 }
 
+type PacketWriter interface {
+	WritePacketData(data []byte) error
+	Close()
+}
+
 type TCPPacketGenerator struct {
-	handle     *pcap.Handle
+	handle     PacketWriter
 	SourceMAC  net.HardwareAddr
 	DestMAC    net.HardwareAddr
 	SourceIP   net.IP
@@ -38,7 +42,7 @@ type TCPPacketGenerator struct {
 	c_s Endpoint
 }
 
-func NewTCPPacketGenerator(handle *pcap.Handle) (*TCPPacketGenerator, error) {
+func NewTCPPacketGenerator(handle PacketWriter) (*TCPPacketGenerator, error) {
 	//TODO: move to params or whatever
 	smac := "00:00:00:00:00:01"
 	dmac := "00:00:00:00:00:02"


### PR DESCRIPTION
This will write directly to name.pcap, so we can skip the extra tcpdump invocation and requiring root. This seems to be the more usual operation: Get a pcap from an OSS Fuzz, not requiring to replay makes life easier.

Relates to #6